### PR TITLE
Build Gatsby and Sanity projects based on changed files

### DIFF
--- a/.github/workflows/build_gatsby.yml
+++ b/.github/workflows/build_gatsby.yml
@@ -1,0 +1,21 @@
+on:
+  push:
+    paths-ignore:
+    - 'sanity/**'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    name: Build Gatsby Application
+    steps:
+    - uses: actions/checkout@master
+    - name: Add NPM token
+      run: "echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > ~/.npmrc"
+      env:
+        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - name: NPM install
+      run: "npm install"
+    - name: Build app
+      run: "npm run build"
+      env:
+        SANITY_READ_TOKEN: ${{ secrets.SANITY_READ_TOKEN }}

--- a/.github/workflows/build_sanity.yml
+++ b/.github/workflows/build_sanity.yml
@@ -1,18 +1,19 @@
-on: push
+on:
+  push:
+    paths:
+    - 'sanity/**'
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    name: Build
+    name: Build Sanity Application
     steps:
     - uses: actions/checkout@master
-    - name: Add NPM token
-      run: "echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > ~/.npmrc"
-      env:
-        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     - name: NPM install
       run: "npm install"
+      working-directory: 'sanity'
     - name: Build app
-      run: "npm run build"
+      run: "./node_modules/.bin/sanity build"
       env:
         SANITY_READ_TOKEN: ${{ secrets.SANITY_READ_TOKEN }}
+      working-directory: 'sanity'

--- a/sanity/package-lock.json
+++ b/sanity/package-lock.json
@@ -940,6 +940,12 @@
         "promise-props-recursive": "^1.0.0"
       }
     },
+    "@sanity/cli": {
+      "version": "0.147.8",
+      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-0.147.8.tgz",
+      "integrity": "sha512-40l/s2DTh5q4iAcTKe8aCNNbF2aEk+030rFQldJrxmd49Ttgq+LCoaPyXO8sA8kOHGldB6tf0WERBXBvjgFYZA==",
+      "dev": true
+    },
     "@sanity/client": {
       "version": "0.142.6",
       "resolved": "https://registry.npmjs.org/@sanity/client/-/client-0.142.6.tgz",

--- a/sanity/package.json
+++ b/sanity/package.json
@@ -26,6 +26,7 @@
     "sanity-plugin-markdown": "^1.0.1"
   },
   "devDependencies": {
+    "@sanity/cli": "^0.147.8",
     "yargs": "^14.2.0"
   }
 }


### PR DESCRIPTION
This PR updates the GitHub Actions workflow to:
- Build the Sanity project/schema when changes occur in the `sanity` directory
- Builds the Gatsby project when things change anywhere else in the project (_not_ in the `sanity` directory)

Example working Gatsby build: https://github.com/cloudflare/built-with-workers/actions/runs/32660067
Example working Sanity build: https://github.com/cloudflare/built-with-workers/actions/runs/32660072

Closes #8