### PR TITLE
Fix 404 rendering instead of returning 1011 error

### DIFF
--- a/workers-site/edge_state.js
+++ b/workers-site/edge_state.js
@@ -13,10 +13,7 @@ class EdgeStateEmbed {
   }
 }
 
-export const hydrateEdgeState = async ({ state, response }) => {
-  const rewriter = new HTMLRewriter().on(
-    "body",
-    new EdgeStateEmbed(await state)
-  )
-  return rewriter.transform(await response)
+export const hydrateEdgeState = ({ state, response }) => {
+  const rewriter = new HTMLRewriter().on("body", new EdgeStateEmbed(state))
+  return rewriter.transform(response)
 }

--- a/workers-site/index.js
+++ b/workers-site/index.js
@@ -53,17 +53,19 @@ async function handleEvent(event) {
         bypassCache: true,
       }
     }
-    return hydrateEdgeState({
-      response: getAssetFromKV(event, options),
-      state: transformBookmark(event.request),
-    })
+    const response = await getAssetFromKV(event, options)
+    const state = await transformBookmark(event.request)
+    return hydrateEdgeState({ response, state })
   } catch (e) {
     // if an error is thrown try to serve the asset at 404.html
     if (!DEBUG) {
       try {
         let notFoundResponse = await getAssetFromKV(event, {
           mapRequestToAsset: req =>
-            new Request(`${new URL(req.url).origin}/404.html`, req),
+            new Request(
+              `${new URL(req.url).origin}/built-with/404/index.html`,
+              req
+            ),
         })
 
         return new Response(notFoundResponse.body, {


### PR DESCRIPTION
This PR fixes a few issues with the way the Workers script was written for this project -- when an asset isn't able to be found, it now correctly renders the route `/built-with/404/index.html`. Hooray for error pages!

Closes #86